### PR TITLE
conduit-mcp support HTTP/SSE host mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Conduit is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/intr
 ## Conduit
 **Modern HTTP Client**: Built with `httpx` for HTTP/2 support and better performance
 
-**Sync & Async**: Both synchronous and asynchronous API clients
-
 **MCP Integration**: Ready-to-use MCP tools for task management
 
 **Type Safety**: Full type hints for better development experience
@@ -28,18 +26,30 @@ uvx --from git+https://github.com/mcpnow-io/conduit conduit-mcp
 ### Docker
 We are still working on Docker support. We estimate it will be available soon.
 
+### As HTTP/SSE Server
+Conduit can run as an HTTP/SSE server for multi-user scenarios. This mode allows multiple clients to connect simultaneously, each using their own authentication tokens.
+
+```sh
+conduit-mcp --host 127.0.0.1 --port 8000 # or using python3 run.py if not installed this repo as package
+```
+When running as an HTTP server, authentication tokens are provided via HTTP headers instead of environment variables.
+
+```
+X-PHABRICATOR-TOKEN: your-32-character-token-here
+```
+
 ## Configuration
 Before running the server, you need to set up the following environment variables:
 
 ### Environment Variables
-
-```bash
+```sh
 export PHABRICATOR_TOKEN=your-api-token-here
 export PHABRICATOR_URL="https://your-phabricator-instance.com/api/"
 
 export PHABRICATOR_PROXY="socks5://127.0.0.1:1080"  # Optional, if your network is behind a firewall
 export PHABRICATOR_DISABLE_CERT_VERIFY=1  # Optional, if your network is under HTTPS filter (WARNING: Disabling certificate verification can expose you to security risks. Only set this if you trust your network environment.)
 ```
+Do note that in HTTPS/SSE mode, `PHABRICATOR_TOKEN` is NOT needed.
 
 ### Getting Your API Token
 1. Log into your Phabricator instance

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ if dev_requirements_path.exists():
 
 setup(
     name="conduit-mcp",
-    version="0.1.1",
+    version="0.1.2",
     author="mcpnow.io",
     author_email="support@mcpnow.io",
     description="The MCP Server for Phabricator and Phorge",

--- a/src/conduit.py
+++ b/src/conduit.py
@@ -1,27 +1,29 @@
+import argparse
 import os
 
 from fastmcp import FastMCP
+from fastmcp.server.dependencies import get_http_headers
 
 from src.client import PhabricatorClient
 from src.tools import register_tools
 
 
 class PhabricatorConfig(object):
-    def __init__(self):
-        self.token = os.getenv("PHABRICATOR_TOKEN")
+    def __init__(self, token=None, require_token=True):
+        self.token = token or os.getenv("PHABRICATOR_TOKEN")
         self.url = os.getenv("PHABRICATOR_URL")
         self.proxy = os.getenv("PHABRICATOR_PROXY")
         self.disable_cert_verify = os.getenv(
             "PHABRICATOR_DISABLE_CERT_VERIFY", ""
         ).lower() in ("1", "true", "yes")
 
-        if not self.token:
-            raise ValueError("PHABRICATOR_TOKEN environment variable is required")
+        if require_token and not self.token:
+            raise ValueError("PHABRICATOR_TOKEN is required")
 
         if not self.url:
             raise ValueError("PHABRICATOR_URL environment variable is required")
 
-        if len(self.token) != 32:
+        if self.token and len(self.token) != 32:
             raise ValueError("PHABRICATOR_TOKEN must be exactly 32 characters long")
 
         if not self.url.startswith(("http://", "https://")):
@@ -43,31 +45,52 @@ mcp = FastMCP("Conduit")
 
 config = None
 client = None
+use_sse = None
 
 
 def get_config():
     global config
     if config is None:
-        config = PhabricatorConfig()
+        config = PhabricatorConfig(require_token=False)
     return config
 
 
 def get_client():
     global client
-    if client is None:
-        config = get_config()
-        client = PhabricatorClient(
+
+    headers = get_http_headers()
+    http_token = headers.get("x-phabricator-token")
+
+    config = get_config()
+
+    if http_token:
+        if len(http_token) != 32:
+            raise ValueError(
+                "PHABRICATOR_TOKEN from HTTP header must be exactly 32 characters long"
+            )
+
+        return PhabricatorClient(
             config.url,
-            config.token,
+            http_token,
             proxy=config.proxy,
             disable_cert_verify=config.disable_cert_verify,
         )
-    return client
+    elif use_sse:
+        raise ValueError("Must provide X-PHABRICATOR-TOKEN.")
+    elif not use_sse:
+        if client is None:
+            if not config.token:
+                raise ValueError("PHABRICATOR_TOKEN is required for stdio mode")
+            client = PhabricatorClient(
+                config.url,
+                config.token,
+                proxy=config.proxy,
+                disable_cert_verify=config.disable_cert_verify,
+            )
+        return client
 
 
-def main():
-    config = PhabricatorConfig()
-
+def print_server_info(config):
     print("Starting Conduit MCP Server...")
     print(f"Phabricator URL: {config.url}")
     print(f"Token configured: {'Yes' if config.token else 'No'}")
@@ -78,9 +101,71 @@ def main():
         f"SSL certificate verification: {'Disabled' if config.disable_cert_verify else 'Enabled'}"
     )
 
+
+def should_use_sse_transport() -> bool:
+    import sys
+
+    sse_args = ["--host", "-H", "--port", "-p"]
+    return any(arg in sys.argv for arg in sse_args)
+
+
+def run_sse_mode(args):
+    print(f"Starting in HTTP/SSE mode on {args.host}:{args.port}")
+    mcp.run(
+        transport="sse",
+        host=args.host,
+        port=args.port,
+        path="/sse",
+    )
+
+
+def run_stdio_mode():
+    print("Starting in stdio mode")
+    mcp.run(transport="stdio")
+
+
+def main():
+    global config, use_sse
+
+    parser = argparse.ArgumentParser(
+        description="Conduit MCP Server for Phabricator and Phorge"
+    )
+    parser.add_argument(
+        "--host",
+        "-H",
+        default="127.0.0.1",
+        help="Host to bind to for SSE transport (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--port",
+        "-p",
+        type=int,
+        default=8000,
+        help="Port to bind to for SSE transport (default: 8000)",
+    )
+
+    args = parser.parse_args()
+
+    use_sse = should_use_sse_transport()
+
+    if use_sse:
+        config = PhabricatorConfig(require_token=False)
+        print_server_info(config)
+
+        print(
+            "Note: In HTTP/SSE mode, PHABRICATOR_TOKEN should be provided via HTTP headers:"
+        )
+        print("  - X-PHABRICATOR-TOKEN: <token>")
+    else:
+        config = PhabricatorConfig(require_token=True)
+        print_server_info(config)
+
     register_tools(mcp, get_client)
 
-    mcp.run(transport="stdio")
+    if use_sse:
+        run_sse_mode(args)
+    else:
+        run_stdio_mode()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Conduit can run as an HTTP/SSE server for multi-user scenarios. This mode allows multiple clients to connect simultaneously, each using their own authentication tokens.

```sh
conduit-mcp --host 127.0.0.1 --port 8000 # or using python3 run.py if not installed this repo as package
```
When running as an HTTP server, authentication tokens are provided via HTTP headers instead of environment variables.

```
X-PHABRICATOR-TOKEN: your-32-character-token-here
```

Do note that the environment variables `PHABRICATOR_TOKEN` is NOT necessary when running in HTTPS/SSE mode.

Tested in local environment. More unittest coverage needed.