### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
 on: [push, workflow_dispatch]
+permissions:
+  contents: read
 
 jobs:
   ci:


### PR DESCRIPTION
Potential fix for [https://github.com/mcpnow-io/conduit/security/code-scanning/2](https://github.com/mcpnow-io/conduit/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will apply to all jobs in the workflow unless overridden by a job-specific `permissions` block. Based on the workflow's actions, it only needs read access to repository contents (`contents: read`) and no write permissions. This ensures the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
